### PR TITLE
Update README and examples

### DIFF
--- a/.github/workflows/go-action.yml
+++ b/.github/workflows/go-action.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           go-version: ">=1.18.0"
       - name: Run snapshot action
-        uses: dsp-testing/go-snapshot-action@main
+        uses: actions/go-dependency-submission@main
         with:
           go-mod-path: go-example/go.mod
           go-build-target: go-example/cmd/octocat.go

--- a/.github/workflows/go-dependency-submission.yml
+++ b/.github/workflows/go-dependency-submission.yml
@@ -1,8 +1,12 @@
-name: Go Action detection of dependencies
-on:
+name: Go Dependency Submission
+on
   push:
     branches:
       - main
+
+# The API requires write permission on the repository to submit dependencies
+permissions:
+  contents: write
 
 jobs:
   go-action-detection:
@@ -10,9 +14,11 @@ jobs:
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v3
+
       - uses: actions/setup-go@v3
         with:
           go-version: ">=1.18.0"
+
       - name: Run snapshot action
         uses: actions/go-dependency-submission@main
         with:

--- a/README.md
+++ b/README.md
@@ -10,19 +10,27 @@ on:
   push:
     branches:
       - main
+
+# The API requires write permission on the repository to submit dependencies
+permissions:
+  contents: write
+
 # Environment variables to configure Go and Go modules. Customize as necessary
 env:
   GOPROXY: '' # A Go Proxy server to be used
   GOPRIVATE: '' # A list of modules are considered private and not requested from GOPROXY
+
 jobs:
   go-action-detection:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v3
+
       - uses: actions/setup-go@v3
         with:
           go-version: ">=1.18.0"
+
       - name: Run snapshot action
         uses: actions/go-dependency-submission@main
         with:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ on:
   push:
     branches:
       - main
-# Envionment variables to configure Go and Go modules. Customize as necessary
+# Environment variables to configure Go and Go modules. Customize as necessary
 env:
   GOPROXY: '' # A Go Proxy server to be used
   GOPRIVATE: '' # A list of modules are considered private and not requested from GOPROXY
@@ -30,7 +30,7 @@ jobs:
             # build target
             go-mod-path: go-example/go.mod
             #
-            # Optinoal: Define the path of a build target (a file with a
+            # Optional: Define the path of a build target (a file with a
             # `main()` function) If not defined, this Action will collect all
             # dependencies used by all build targets for the module, which may
             # include Go dependencies used by tests and tooling.


### PR DESCRIPTION
Add the permissions clause that will be required in any org that has reduced default token permissions.

Fix some spelling and formatting.

Make our own use of this action have correct url and a more specific name.