### PR TITLE
Update yml to use semver tag instead of main ref

### DIFF
--- a/.github/workflows/go-dependency-submission.yml
+++ b/.github/workflows/go-dependency-submission.yml
@@ -20,7 +20,7 @@ jobs:
           go-version: ">=1.18.0"
 
       - name: Run snapshot action
-        uses: actions/go-dependency-submission@main
+        uses: actions/go-dependency-submission@v1
         with:
           go-mod-path: go-example/go.mod
           go-build-target: go-example/cmd/octocat.go

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
           go-version: ">=1.18.0"
 
       - name: Run snapshot action
-        uses: actions/go-dependency-submission@main
+        uses: actions/go-dependency-submission@v1
         with:
             # Required: Define the repo path to the go.mod file used by the
             # build target


### PR DESCRIPTION
Update to use `@v1` instead of `@main` in `go-dependency-submission.yml`