### PR TITLE
Add default value for go-mod-path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,8 @@ inputs:
     description: 'User provided map of max key/value pairs of metadata to include with the snapshot e.g. {"lastModified": "12-31-2022"}'
   go-mod-path:
     required: true
-    description: 'Repo path to the go.mod file used to detect dependencies for the Go build target'
+    description: 'Repo path to the go.mod file used to detect dependencies for the Go build target. Defaults to go.mod in the root of the repository.'
+    default: 'go.mod'
   go-build-target:
     required: true
     description: 'Build target to detect build dependencies. If unspecified, will use "all", with will detect all dependencies used in all build targets (including tests and tools).'


### PR DESCRIPTION
I noticed that we don't have a default value for the `go-mod-path`, even though it's usually at the root of the repository. I propose adding the default value here. 