### PR TITLE
Add publish-action to sync major release tags to latest minor

### DIFF
--- a/.github/workflows/release-new-action-version.yml
+++ b/.github/workflows/release-new-action-version.yml
@@ -1,0 +1,26 @@
+name: Release new action version
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      TAG_NAME:
+        description: 'Tag name that the major tag will point to'
+        required: true
+
+env:
+  TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}
+permissions:
+  contents: write
+
+jobs:
+  update_tag:
+    name: Update the major tag to include the ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }} changes
+    environment:
+      name: releaseNewActionVersion
+    runs-on: ubuntu-latest
+    steps:
+    - name: Update the ${{ env.TAG_NAME }} tag
+      uses: actions/publish-action@v0.1.0
+      with:
+        source-tag: ${{ env.TAG_NAME }}


### PR DESCRIPTION
This action provides a relatively minor convenience around releases. When creating a new release, the version should be given as something like `v1.0.3`. Seeing that, this action will automatically update the `v1` tag to point to the newest minor release matching the major number.

That way, users of this action who pin to (in this example) `v1` will always get the latest point release.

See [this doc](https://github.com/actions/toolkit/blob/main/docs/action-versioning.md#recommendations) for a bit more background on this convention.

I ran this on my own fork to verify that it works. You can see the action output [here](https://github.com/juxtin/go-dependency-submission/runs/7982768683?check_suite_focus=true).