### PR TITLE
Fix safe harbor policy link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,4 +28,4 @@ This information will help us triage your report more quickly.
 
 ## Policy
 
-See [GitHub's Safe Harbor Policy](https://docs.github.com/en/github/site-policy/github-bug-bounty-program-legal-safe-harbor#1-safe-harbor-terms)
+See [GitHub's Safe Harbor Policy](https://docs.github.com/en/site-policy/security-policies/github-bug-bounty-program-legal-safe-harbor#1-safe-harbor-terms)


### PR DESCRIPTION
The safe harbor policy link in the security policy is broken; this PR updates it.