### PR TITLE
Update Node and GitHub Actions versions to latest

### DIFF
--- a/.github/workflows/go-dependency-submission.yml
+++ b/.github/workflows/go-dependency-submission.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: ">=1.18.0"
 

--- a/action.yml
+++ b/action.yml
@@ -46,5 +46,5 @@ inputs:
     required: false
     default: ''
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,9 @@
         "prettier": "^3.5.3",
         "ts-jest": "^29.0.0",
         "typescript": "^4.6.4"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.0.3",
   "description": "Go Dependency Submission",
   "main": "dist/index.js",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "build": "tsc",
     "format": "npx prettier --write '**/*.ts'",


### PR DESCRIPTION
Bump Node.js engine requirement to >=24 in package.json and package-lock.json. Update action.yml to use node24. Upgrade actions/checkout to v4 and actions/setup-go to v5 in the workflow. These changes ensure compatibility with the latest Node.js and GitHub Actions tooling.