### PR TITLE
Add actions and go to CodeQL analysis languages

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript-typescript' ]
+        language: [ 'javascript-typescript', 'actions', 'go' ]
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
- Relates to: https://github.com/github/vuln-mgmt/issues/162405

We need to add `go` and `actions` to the codeQL configuration