### PR TITLE
fix(action): correct input names and remove invalid fields in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,43 +6,35 @@ inputs:
     description: "GitHub Personal Access Token (PAT). Defaults to PAT provided by Action runner"
     required: false
     default: ${{ github.token }}
-  metadata:
-    required: false
-    description: 'User provided map of max key/value pairs of metadata to include with the snapshot e.g. {"lastModified": "12-31-2022"}'
   go-mod-path:
-    required: true
+    required: false
     description: 'Repo path to the go.mod file used to detect dependencies for the Go build target. Defaults to go.mod in the root of the repository.'
     default: 'go.mod'
   go-build-target:
-    required: true
+    required: false
     description: 'Build target to detect build dependencies. If unspecified, will use "all", with will detect all dependencies used in all build targets (including tests and tools).'
     default: 'all'
-  snapshot-sha:
+  sha:
     description: The SHA that the results will be linked to in the dependency snapshot
-    type: string
     required: false
     default: ''
-  snapshot-ref:
+  ref:
     description: The ref that the results will be linked to in the dependency snapshot
-    type: string
     required: false
     default: ''
 
-  # If any of detector-name, detector-version, or detector-url are provided, they all have to be provided.  
+  # If any of detector-name, detector-version, or detector-url are provided, they all have to be provided.
   # Defaults will be used if none are not provided.  If only one or two are provided, the action will fail.
   detector-name:
     description: The name of the detector that generated the dependency snapshot
-    type: string
     required: false
     default: ''
   detector-version:
     description: The version of the detector that generated the dependency snapshot
-    type: string
     required: false
     default: ''
   detector-url:
     description: The URL to the detector that generated the dependency snapshot
-    type: string
     required: false
     default: ''
 runs:


### PR DESCRIPTION
## Summary
Corrects several inaccuracies in `action.yml` that caused inputs to be non-functional or misrepresented to callers. No behavior changes to the runtime logic — all fixes are confined to the action metadata file.

## Changes
- **`snapshot-sha` → `sha`**: Renamed to match `core.getInput('sha')` called in `index.ts`. The old name was never read by the implementation.
- **`snapshot-ref` → `ref`**: Same — renamed to match `core.getInput('ref')`.
- **Removed `metadata` input**: Declared with a description but `core.getInput('metadata')` is never called anywhere in the source; the input had no effect.
- **Removed `type:` fields**: `type` is not a valid field for GitHub Actions inputs. It was present on `sha`, `ref`, `detector-name`, `detector-version`, and `detector-url` and was silently ignored by the runner.
- **`go-mod-path` / `go-build-target`: `required: true` → `required: false`**: Both inputs have `default:` values set, making `required: true` contradictory — callers are not actually required to supply them.

## Motivation
The `snapshot-sha` and `snapshot-ref` inputs were documented and exposed to users but **never functioned** — the implementation reads `sha` and `ref` respectively. Any workflow that set these inputs was silently ignoring them, always falling back to the context SHA/ref.

The `required: true` + `default:` combination on `go-mod-path` and `go-build-target` gave callers a false impression that they must provide these values, discouraging use of the built-in defaults.

## Impact
- **`sha` / `ref` rename**: Any existing workflow using `snapshot-sha` or `snapshot-ref` will need to update to `sha` and `ref`. Since those inputs were never read by the code, existing workflows were already not benefiting from them — this change makes the feature work for the first time.
- **`metadata` removal**: No functional impact; the input was a no-op.
- **`required` flag corrections**: No runtime impact; purely a documentation fix for tooling and UI that surfaces input metadata.
- **`type:` removal**: No runtime impact; the field was already ignored by the runner.

## Testing
- Confirm `action.yml` is valid YAML and accepted by `action-validator` or equivalent.
- In a test workflow, set `sha: <some-sha>` and `ref: refs/heads/some-branch` and verify the submitted snapshot reflects those values (previously impossible with the old names).